### PR TITLE
ST-84191: Upgrade google-java-format to 1.25.2 in order to upgrade jdk to 21

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 mkdir -p .cache
 cd .cache
-if [ ! -f google-java-format-1.16.0-all-deps.jar ]
+if [ ! -f google-java-format-1.25.2-all-deps.jar ]
 then
-    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar"
-    chmod 755 google-java-format-1.16.0-all-deps.jar
+    curl -LJO "https://github.com/google/google-java-format/releases/download/v1.25.2/google-java-format-1.25.2-all-deps.jar"
+    chmod 755 google-java-format-1.25.2-all-deps.jar
 fi
 cd ..
 
-java -jar .cache/google-java-format-1.16.0-all-deps.jar --replace $@
+java -jar .cache/google-java-format-1.25.2-all-deps.jar --replace $@


### PR DESCRIPTION
## Description
Upgrade google-java-format to 1.25.2 in order to upgrade jdk to 21

## Jira
https://spotnana.atlassian.net/browse/ST-84191